### PR TITLE
fix a typo

### DIFF
--- a/minimal.html
+++ b/minimal.html
@@ -84,7 +84,7 @@ $ su
 # mount /dev/mmcblk0p2 /mnt
 # umask 077
 # mkdir /mnt/root/.ssh
-# cat $HOME/.ssh/id_rsa.pub &gt;/mnt/root/.ssh/aurhorized_keys
+# cat $HOME/.ssh/id_rsa.pub &gt;/mnt/root/.ssh/authorized_keys
 # umount /mnt
 </pre>
 


### PR DESCRIPTION
Fix a typo which prevents user to blindly copy/paste commands to his terminal without knowing what they do.
